### PR TITLE
Bump pnet version to 0.35

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.pnet]
-version = "0.27.2"
+version = "0.35"
 
 # https://github.com/libpnet/libpnet/issues/481
 [target.'cfg(windows)'.dependencies]

--- a/src/pdu.rs
+++ b/src/pdu.rs
@@ -2,7 +2,7 @@
 #![allow(non_camel_case_types)]
 
 use crate::error::GooseError;
-use crate::types::{*};
+pub use crate::types::{*};
 
 use crate::pdu_encoder::{*};
 use crate::pdu_decoder::{*};
@@ -136,7 +136,7 @@ pub fn decodeEthernetHeader(header: & mut EthernetHeader, buffer: &[u8], pos:usi
     //println!("decode header {:?}",header);
 
     new_pos=new_pos+2;  // reserved 1
-    
+
     new_pos=new_pos+2; // reserved 2
 
     Ok(new_pos)

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,7 +2,7 @@
 #![allow(non_camel_case_types)]
 use serde::{Serialize, Deserialize};
 
-#[derive(Debug,Serialize, Deserialize)]
+#[derive(Debug,Serialize, Deserialize, Clone)]
 pub enum IECData{
     array(Vec<IECData>),
     structure(Vec<IECData>),
@@ -26,7 +26,7 @@ pub enum IECData{
     octet_string(Vec<u8>),
     utc_time([u8;8])
 }
-#[derive(Debug,Default)]
+#[derive(Debug,Default,Clone)]
 pub struct EthernetHeader {
     pub srcAddr:[u8;6],
     pub dstAddr:[u8;6],
@@ -37,7 +37,7 @@ pub struct EthernetHeader {
     pub length:[u8;2]
 }
 
-#[derive(Debug,Default)]
+#[derive(Debug,Default,Clone)]
 pub struct IECGoosePdu {
     pub gocbRef: String,
     pub timeAllowedtoLive: u32,


### PR DESCRIPTION
Bump pnet version to 0.35
there is an error building with 0.27.2
`error: failed to run custom build command for "pnet_packet v0.27.2"`